### PR TITLE
Minor optimization using isset()

### DIFF
--- a/src/Objects/DataObject.php
+++ b/src/Objects/DataObject.php
@@ -176,7 +176,7 @@ abstract class DataObject implements Arrayable, Jsonable, Rawable
      */
     public function __get($key)
     {
-        if (iseet($this->data[$key])) {
+        if (isset($this->data[$key])) {
             return $this->data[$key];
         }
 

--- a/src/Objects/DataObject.php
+++ b/src/Objects/DataObject.php
@@ -50,7 +50,7 @@ abstract class DataObject implements Arrayable, Jsonable, Rawable
     protected function mapRelations()
     {
         foreach (static::relations() as $property => $type) {
-            if (array_key_exists($property, $this->data) && ! is_null($this->data[$property])) {
+            if (isset($this->data[$property])) {
                 $this->data[$property] = Casting::cast($this->data[$property], $type, $property);
             }
         }
@@ -176,7 +176,7 @@ abstract class DataObject implements Arrayable, Jsonable, Rawable
      */
     public function __get($key)
     {
-        if (array_key_exists($key, $this->data)) {
+        if (iseet($this->data[$key])) {
             return $this->data[$key];
         }
 


### PR DESCRIPTION
`isset()` is about 2-3x faster than `array_key_exists()`. The first usage has a redundant `is_null` which is not needed once switching to `isset` since it returns false if null.

Btw I see another minor optimization but I'm not sure if you'd want it - in `fuse()`, you could do `array_flip` on `except` before the foreach loop, then use `isset()` inside the loop instead of `in_array`. O(n) + O(1) instead of O(n * m). Obviously $except is an optional feature and I never expect it to be large, but still an optimization! 😄